### PR TITLE
✨ 업로드 시 metadata content type 지정

### DIFF
--- a/friends/package.json
+++ b/friends/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "build:android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output dist/android.jsbundle --assets-dest android/com/wafflestudio/snutt-staging/src/main/res/",
     "build:ios": "react-native bundle --dev false --entry-file index.js --bundle-output dist/ios.jsbundle --assets-dest ./ios --platform ios",
-    "deploy:all": "yarn build:android && yarn build:ios && aws s3 sync dist s3://snutt-rn-assets --delete"
+    "deploy:all": "yarn build:android && yarn build:ios && aws s3 sync dist s3://snutt-rn-assets --delete --content-type 'application/javascript'"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
따로 지정하지 않으면 `binary/octet-stream` 으로 들어가는데, 이러면 ios에서 못 알아듣습니다.