### PR TITLE
🚸 친구 이름 수정 중에 취소 클릭하면 바텀시트 닫지 말고 친구 수정뷰로

### DIFF
--- a/friends/src/app/screens/MainScreen/ManageFriendsDrawerContent/ManageFriendsDrawerContentActiveList/index.tsx
+++ b/friends/src/app/screens/MainScreen/ManageFriendsDrawerContent/ManageFriendsDrawerContentActiveList/index.tsx
@@ -97,7 +97,11 @@ export const ManageFriendsDrawerContentActiveList = ({ onClickFriend }: Props) =
         ) : (
           <View style={styles.displayNameSheetContent}>
             <BottomSheet.Header
-              left={{ text: '취소', onPress: () => setBottomSheetState({ isOpen: false }) }}
+              left={{
+                text: '취소',
+                onPress: () =>
+                  setBottomSheetState({ isOpen: true, type: 'detail', friendId: bottomSheetState.friendId }),
+              }}
               right={{
                 text: '적용',
                 onPress: () =>


### PR DESCRIPTION
fixed https://www.notion.so/wafflestudio/7c88cfea62cc4673bb10c3f7d8eb924e?pvs=4