### PR TITLE
Playwright 1.40.1 -> 1.61.1 업그레이드 및 snutt-webclient e2e 테스트 수정

### DIFF
--- a/apps/snutt-ev-webview/package.json
+++ b/apps/snutt-ev-webview/package.json
@@ -17,7 +17,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@playwright/test": "1.40.1",
+    "@playwright/test": "1.61.1",
     "@types/js-cookie": "3.0.6",
     "@types/node": "20.12.12",
     "@types/react": "18.3.2",

--- a/apps/snutt-webclient/e2e/common/footer.spec.ts
+++ b/apps/snutt-webclient/e2e/common/footer.spec.ts
@@ -48,13 +48,13 @@ test('개발자 괴롭히기 기능이 잘 동작한다 (정상 제출)', async 
   await givenUser(page, { login: true });
   await page.getByText('개발자 괴롭히기').click();
   await expect(page.getByTestId('feedback-submit')).toBeDisabled();
-  await page.getByTestId('feedback-email').type('test1');
+  await page.getByTestId('feedback-email').type('test1@test.com');
   await expect(page.getByTestId('feedback-submit')).toBeDisabled();
   await page.getByTestId('feedback-message').type('test2');
   await Promise.all([
     page.waitForRequest(
       (req) =>
-        req.postDataJSON().email === 'test1' &&
+        req.postDataJSON().email === 'test1@test.com' &&
         req.postDataJSON().message === 'test2' &&
         req.url().includes('/v1/feedback') &&
         req.method() === 'POST',

--- a/apps/snutt-webclient/e2e/landing/find-password.spec.ts
+++ b/apps/snutt-webclient/e2e/landing/find-password.spec.ts
@@ -93,6 +93,7 @@ test('Step 3: 코드 입력이 잘 된다 (기본)', async ({ page }) => {
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).type('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
 
   // test
@@ -124,7 +125,9 @@ test('Step 3: 코드 입력이 잘 된다 (만료)', async ({ browser }) => {
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).type('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('인증코드를 입력해주세요.');
 
   // test
   await page.getByTestId(testIds['인풋']).type('코드');
@@ -144,7 +147,9 @@ test('Step 3: 코드 입력이 잘 된다 (인증한적 없음)', async ({ brows
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).type('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('인증코드를 입력해주세요.');
 
   // test
   await page.getByTestId(testIds['인풋']).type('code');
@@ -164,7 +169,9 @@ test('Step 3: 코드 입력이 잘 된다 (틀림)', async ({ browser }) => {
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).type('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('인증코드를 입력해주세요.');
 
   // test
   await page.getByTestId(testIds['인풋']).type('코드');
@@ -182,7 +189,9 @@ test('Step 4: 비밀번호 변경이 잘 된다 (기본)', async ({ page }) => {
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).type('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('인증코드를 입력해주세요.');
   await page.getByTestId(testIds['인풋']).type('코드');
   await page.getByTestId(testIds['버튼']).click();
 
@@ -213,9 +222,12 @@ test('Step 5: 비밀번호 변경이 잘 된다 (기본)', async ({ page }) => {
   await page.getByTestId(testIds['비밀번호 재설정 버튼']).click();
   await page.getByTestId(testIds['인풋']).fill('woohm402');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('아래 이메일로 인증코드를 전송합니다.');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('인증코드를 입력해주세요.');
   await page.getByTestId(testIds['인풋']).fill('코드');
   await page.getByTestId(testIds['버튼']).click();
+  await expect(page.getByTestId(testIds['설명'])).toHaveText('새 비밀번호를 입력해주세요.');
   await page.getByTestId(testIds['인풋']).fill('qwerqwer');
   await page.getByTestId(testIds['버튼']).click();
 

--- a/apps/snutt-webclient/e2e/main/add-lecture-dialog.spec.ts
+++ b/apps/snutt-webclient/e2e/main/add-lecture-dialog.spec.ts
@@ -21,7 +21,7 @@ test('강의 생성 모달이 잘 보여진다 (성공 케이스)', async ({ pag
 
   await expect(page.getByTestId(testIds['강의명 필드'])).toHaveValue('');
   await page.getByTestId(testIds['강의명 필드']).fill('떡볶이맛 아몬드');
-  await page.getByTestId(testIds['강의 색 칩']).filter({ hasText: '라벤더' }).click();
+  await page.getByTestId(testIds['강의 색 칩']).filter({ hasText: 'SNUTT 8' }).click();
   await page.getByTestId(testIds['강의 시간 추가 버튼']).click();
   await page.getByTestId(testIds['강의 시간 행']).nth(0).locator('input').nth(2).fill('낙아치');
   await Promise.all([
@@ -82,8 +82,8 @@ test('커스텀 색 관련 ui가 잘 보여진다', async ({ page }) => {
   await page.getByTestId(testIds['강의 추가하기 버튼']).click();
   const cLabels = {
     커스텀: page.getByTestId('main-lecture-edit-form-custom-color'),
-    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '하늘' }),
-    감귤: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '감귤' }),
+    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 7' }),
+    감귤: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 2' }),
   };
 
   await expect(cLabels['커스텀']).toHaveValue('#888888');

--- a/apps/snutt-webclient/e2e/main/edit-lecture-dialog.spec.ts
+++ b/apps/snutt-webclient/e2e/main/edit-lecture-dialog.spec.ts
@@ -16,7 +16,7 @@ test('강의 수정 모달이 잘 보인다 (성공케이스)', async ({ page })
   await lectureItem.filter({ hasText: '컴퓨터공학부, 2학년' }).click();
   await expect(page.getByTestId('main-lecture-edit-form-title')).toHaveValue('컴퓨터프로그래밍');
   await page.getByTestId(testIds['교수']).fill('떡볶이맛 아몬드');
-  await page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '라벤더' }).click();
+  await page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 8' }).click();
   await page.getByTestId('main-lecture-edit-form-time').nth(0).locator('input').nth(2).fill('낙아치');
   await page.getByTestId('main-lecture-edit-form-time').nth(1).locator('input').nth(0).click();
   await page.getByTestId('hour-clock').getByText('4', { exact: true }).click();
@@ -28,7 +28,7 @@ test('강의 수정 모달이 잘 보인다 (성공케이스)', async ({ page })
         req.method() === 'PUT' &&
         req.url().includes('/v1/tables/123/lecture/5d1decbddb261b554d609dcc') &&
         req.postDataJSON().class_time_json[0].place === '낙아치' &&
-        req.postDataJSON().class_time_json[1].startMinute === 970 &&
+        req.postDataJSON().class_time_json[1].startMinute === 990 &&
         req.postDataJSON().class_time_json[1].endMinute === 1220 &&
         req.postDataJSON().class_time_json[2].place === '302-208' &&
         req.postDataJSON().course_title === undefined &&
@@ -49,7 +49,7 @@ test('커스텀 색 관련 ui가 잘 보인다 (커스텀 색인 강의)', async
   await page.getByTestId('main-lecture-listitem').filter({ hasText: '진화와 인간사회' }).click();
   const cLabels = {
     커스텀: page.getByTestId('main-lecture-edit-form-custom-color'),
-    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '하늘' }),
+    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 7' }),
   };
 
   await expect(cLabels['커스텀']).toHaveValue('#000000');
@@ -76,8 +76,8 @@ test('커스텀 색 관련 ui가 잘 보인다 (커스텀 색이 아닌 강의)'
   await page.getByTestId('main-lecture-listitem').filter({ hasText: '컴퓨터프로그래밍' }).click();
   const cLabels = {
     커스텀: page.getByTestId('main-lecture-edit-form-custom-color'),
-    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '하늘' }),
-    감귤: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '감귤' }),
+    하늘: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 7' }),
+    감귤: page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 2' }),
   };
 
   await expect(cLabels['커스텀']).toHaveValue('#888888');
@@ -120,7 +120,7 @@ test('커스텀 색에서 잘 수정된다', async ({ page }) => {
   const lectureItem = page.getByTestId('main-lecture-listitem');
   await expect(page.getByTestId('main-lecture-edit-dialog-content')).toHaveCount(0);
   await lectureItem.filter({ hasText: '진화와 인간사회' }).click();
-  await page.getByTestId('main-lecture-edit-form-color').filter({ hasText: '비취' }).click();
+  await page.getByTestId('main-lecture-edit-form-color').filter({ hasText: 'SNUTT 5' }).click();
   await Promise.all([
     page.waitForRequest((req) => req.postDataJSON().colorIndex === 5 && req.postDataJSON().color === undefined),
     page.waitForRequest((req) => req.method() === 'GET' && req.url().includes('/v1/tables/123')),

--- a/apps/snutt-webclient/e2e/main/hour-minute-picker.spec.ts
+++ b/apps/snutt-webclient/e2e/main/hour-minute-picker.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test';
 import { givenUser } from '../utils/user.ts';
 
 test('강의 시간 수정 선택 기능이 엄청 잘 동작한다 (컴프)', async ({ page }) => {
+  test.slow(); // 시나리오가 길어 병렬 실행 시 기본 타임아웃(5000ms)에 종종 걸린다
   await page.goto('/');
   await givenUser(page);
   await page.getByTestId(testIds['강의']).filter({ hasText: '컴퓨터공학부, 2학년' }).click();

--- a/apps/snutt-webclient/e2e/main/lecture-section.spec.ts
+++ b/apps/snutt-webclient/e2e/main/lecture-section.spec.ts
@@ -54,7 +54,7 @@ test('수강편람 버튼이 정상 동작한다', async ({ page, context }) => 
     lectureItem.filter({ hasText: '고급수학 2' }).getByTestId('main-lecture-listitem-link').click(),
   ]);
   await expect(newPage).toHaveURL(
-    'https://sugang.snu.ac.kr/sugang/cc/cc103.action?openSchyy=1001&openShtmFg=U000200001&openDetaShtmFg=U000300001&sbjtCd=L0442.000700&ltNo=001&sbjtSubhCd=000',
+    'https://snutt-proxy.wafflestudio.com/sugang/cc/cc103.action?openSchyy=1001&openShtmFg=U000200001&openDetaShtmFg=U000300001&sbjtCd=L0442.000700&ltNo=001&sbjtSubhCd=000',
   );
   await expect(lectureItem.filter({ hasText: '복싱' }).getByTestId('main-lecture-listitem-link')).toHaveCount(0);
 });

--- a/apps/snutt-webclient/e2e/main/search.spec.ts
+++ b/apps/snutt-webclient/e2e/main/search.spec.ts
@@ -41,7 +41,8 @@ test('검색 기능이 정상 동작한다 (검색 결과 있을 때)', async ({
         req.url().includes('/v1/search_query') &&
         req.postDataJSON().year === 2001 &&
         req.postDataJSON().limit === 200 &&
-        req.postDataJSON().time_mask[0] === 671024127 &&
+        Array.isArray(req.postDataJSON().timesToExclude) &&
+        req.postDataJSON().timesToExclude.length === 17 &&
         req.postDataJSON().etc[0] === 'MO' &&
         req.postDataJSON().etc.length === 1 &&
         req.method() === 'POST',

--- a/apps/snutt-webclient/package.json
+++ b/apps/snutt-webclient/package.json
@@ -30,7 +30,7 @@
     "styled-components": "6.1.11"
   },
   "devDependencies": {
-    "@playwright/test": "1.40.1",
+    "@playwright/test": "1.61.1",
     "@tanstack/eslint-plugin-query": "5.35.6",
     "@types/node": "20.12.12",
     "@types/react": "18.3.2",

--- a/apps/snutt-webclient/src/components/error-boundary/index.ts
+++ b/apps/snutt-webclient/src/components/error-boundary/index.ts
@@ -1,6 +1,6 @@
 import { Component, type PropsWithChildren, type ReactNode } from 'react';
 
-type Props = PropsWithChildren<{ fallback: ReactNode }>;
+type Props = PropsWithChildren<{ fallback: ReactNode; onError?: (error: Error) => void }>;
 
 export class ErrorBoundary extends Component<Props, { hasError: boolean }> {
   constructor(props: Props) {
@@ -11,6 +11,10 @@ export class ErrorBoundary extends Component<Props, { hasError: boolean }> {
   static getDerivedStateFromError() {
     // Update state so the next render will show the fallback UI.
     return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError?.(error);
   }
 
   render() {

--- a/apps/snutt-webclient/src/main.tsx
+++ b/apps/snutt-webclient/src/main.tsx
@@ -1,9 +1,11 @@
+import { getTruffleClient } from '@wafflestudio/truffle-browser';
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
 import { ErrorBoundary } from '@/components/error-boundary';
 import { EnvContext } from '@/contexts/EnvContext';
 import { ErrorPage } from '@/pages/error';
+import { getErrorService } from '@/usecases/errorService';
 
 import { App } from './App';
 
@@ -28,10 +30,18 @@ async function startApp() {
 
   window.git = { sha: ENV.GIT_SHA, tag: ENV.GIT_TAG };
 
+  const errorService = getErrorService({
+    errorCaptureClient: getTruffleClient({
+      enabled: ENV.NODE_ENV === 'production' && ENV.APP_ENV !== 'mock',
+      app: { name: 'snutt-webclient-v2', phase: ENV.APP_ENV },
+      apiKey: ENV.TRUFFLE_API_KEY,
+    }),
+  });
+
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <StrictMode>
       <EnvContext.Provider value={ENV}>
-        <ErrorBoundary fallback={<ErrorPage />}>
+        <ErrorBoundary fallback={<ErrorPage />} onError={(error) => errorService.captureError(error)}>
           <App />
         </ErrorBoundary>
       </EnvContext.Provider>

--- a/apps/snutt-webclient/src/mocks/handlers/index.ts
+++ b/apps/snutt-webclient/src/mocks/handlers/index.ts
@@ -1,5 +1,7 @@
 import { http } from 'msw';
 
+import type { UserAuthProviderInfo } from '@sf/snutt-api/src/apis/snutt/schemas';
+
 import type { SignInResponse } from '@/entities/auth';
 import type { Color } from '@/entities/color';
 import type { CoreServerError } from '@/entities/error';
@@ -82,6 +84,26 @@ export const handlers = [
       if (!user) return { type: 'error', body: { errcode: 8194, ext: {}, message: '' }, status: 403 };
 
       return { type: 'success', body: user.info };
+    }),
+  ),
+
+  http.get<never, never, UserAuthProviderInfo | CoreServerError>(
+    `*/v1/users/me/auth-providers`,
+    withValidateAccess(({ token }) => {
+      const user = mockUsers.find((u) => u.auth.token === token);
+
+      if (!user) return { type: 'error', body: { errcode: 8194, ext: {}, message: '' }, status: 403 };
+
+      return {
+        type: 'success',
+        body: {
+          local: !!user.info.local_id,
+          facebook: !!user.info.fb_name,
+          google: false,
+          kakao: false,
+          apple: false,
+        },
+      };
     }),
   ),
 

--- a/apps/snutt-webclient/src/pages/error/index.tsx
+++ b/apps/snutt-webclient/src/pages/error/index.tsx
@@ -1,17 +1,3 @@
-import { useEffect } from 'react';
-import { useRouteError } from 'react-router-dom';
-
-import { ServiceContext } from '@/contexts/ServiceContext';
-import { useGuardContext } from '@/hooks/useGuardContext';
-
 export const ErrorPage = () => {
-  const error = useRouteError();
-
-  const { errorService } = useGuardContext(ServiceContext);
-
-  useEffect(() => {
-    errorService.captureError(new Error(JSON.stringify(error)));
-  }, [errorService, error]);
-
   return <div>Error</div>;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,12 +2341,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.0.tgz#7d8dacb7fdef0e4387caf7396cbd77f179867d06"
   integrity sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==
 
-"@playwright/test@1.40.1":
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.1.tgz#9e66322d97b1d74b9f8718bacab15080f24cde65"
-  integrity sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==
+"@playwright/test@1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
   dependencies:
-    playwright "1.40.1"
+    playwright "1.61.1"
 
 "@react-native-async-storage/async-storage@1.19.8":
   version "1.19.8"
@@ -8945,17 +8945,17 @@ pkg-types@^1.0.3, pkg-types@^1.1.0:
     mlly "^1.7.0"
     pathe "^1.1.2"
 
-playwright-core@1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.1.tgz#442d15e86866a87d90d07af528e0afabe4c75c05"
-  integrity sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
 
-playwright@1.40.1:
-  version "1.40.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.40.1.tgz#a11bf8dca15be5a194851dbbf3df235b9f53d7ae"
-  integrity sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
   dependencies:
-    playwright-core "1.40.1"
+    playwright-core "1.61.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Summary
- **CI 수정**: `ubuntu-24.04-arm` 러너에서 `yarn playwright install --with-deps`가 Ubuntu 24.04용 패키지(`libasound2`, `libicu70` 등)를 못 찾아 실패하던 문제. `snutt-webclient`, `snutt-ev-webview` 두 앱 모두 `@playwright/test`를 1.61.1로 업그레이드함 (yarn 호이스팅 때문에 둘 중 하나만 올리면 다른 쪽의 구버전 CLI가 루트에 호이스팅되어 실행되므로 둘 다 필요)
- **앱 크래시 수정**: mock 환경에서 `/mypage` 접근 시 두 버그가 겹쳐 앱 전체가 크래시하고 있었음
  - `GET /v1/users/me/auth-providers`에 대한 MSW mock 핸들러 누락 → 요청이 bypass되어 SPA 폴백(200 OK)이 `{type:'success', data:null}`로 오인식되고 `MyPage`가 `Object.keys(null)` 호출로 크래시
  - `ErrorPage`가 `useRouteError()`(data router 전용 훅)를 사용해서, 이 앱의 일반 `BrowserRouter`에서는 ErrorBoundary가 어떤 에러든 잡아 fallback을 그리려 할 때마다 `ErrorPage` 자신이 크래시하며 앱 전체가 언마운트됨 (실제 프로덕션에서도 위험한 버그)
- **e2e 테스트 정리**: 위 크래시 수정 후 남은 10개 실패는 전부 최근 커밋들(#208, #223, #229, #232)이 앱 동작을 바꾸면서 갱신되지 않은 stale assertion들이었고, find-password 플로우에는 실제 레이스 컨디션(연속 클릭이 이전 mutation 완료를 기다리지 않음)이 있었음. 전부 원인 확인 후 수정

## 검증
- 실제 CI 러너와 동일한 환경(Docker, `ubuntu:24.04`, `--platform linux/arm64`)에서 `yarn playwright install --with-deps` 성공 확인
- `yarn test`(vitest + jest) 전체 통과, typecheck/lint 통과
- `CI=true`(실제 GitHub Actions와 동일하게 `workers=1`, `retries=2`) 조건으로 `snutt-webclient` e2e 스위트 **106/106 전부 통과**

## Test plan
- [ ] PR CI에서 `snutt-webclient`, `snutt-ev-webview` 워크플로가 모두 통과하는지 확인