### PR TITLE
  feat: React Native WebView 시간표 공유 지원

### DIFF
--- a/apps/snutt-webclient/src/usecases/timetablePickerService.ts
+++ b/apps/snutt-webclient/src/usecases/timetablePickerService.ts
@@ -1,6 +1,14 @@
 import type { Lecture } from '@/entities/lecture';
 import type { FullTimetable } from '@/entities/timetable';
 
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage(message: string): void;
+    };
+  }
+}
+
 export type SharedLecture = Omit<Lecture, '_id' | 'color' | 'colorIndex'>;
 export type SharedTimetable = Omit<FullTimetable, '_id' | 'user_id' | 'updated_at' | 'theme' | 'lecture_list'> & {
   lecture_list: SharedLecture[];
@@ -32,8 +40,23 @@ export const getTimetablePickerService = (allowedOrigins: readonly string[]): Ti
     isAllowedOrigin,
     sendTimetableToOpener: ({ timetable, targetOrigin, opener }) => {
       // 허용 목록 밖 origin으로는 절대 전송하지 않는다 (호출부 검증 누락 대비).
+
+      const message = {
+        type: 'SNUTT_TIMETABLE_SELECTED',
+        payload: toSharedTimetable(timetable),
+      };
+
+      // React Native WebView 환경
+      if (window.ReactNativeWebView) {
+        if (!isAllowedOrigin(window.location.origin)) return;
+        window.ReactNativeWebView.postMessage(JSON.stringify(message));
+        return;
+      }
+
+      // 일반 웹 환경
       if (!isAllowedOrigin(targetOrigin)) return;
-      opener.postMessage({ type: 'SNUTT_TIMETABLE_SELECTED', payload: toSharedTimetable(timetable) }, targetOrigin);
+      opener.postMessage(message, targetOrigin);
+      
     },
   };
 };


### PR DESCRIPTION
## 변경 내용

시간표 선택기에서 사용자가 시간표를 선택했을 때, 기존 웹 팝업 연동에 더해
React Native WebView 연동을 지원합니다.

선택 결과는 실행 환경에 따라 다음 경로를 통해 전달됩니다.

- 웹 팝업: `window.opener.postMessage(...)`
- React Native WebView: `window.ReactNativeWebView.postMessage(...)`

## 변경 이유
React Native를 기반으로 한 행샤 iOS 앱에서 SNUTT 시간표 불러오기 기능을 구현하고 있습니다.
React Native 모바일 앱에서는 웹의 팝업 및 `window.opener` 기반 흐름을 사용할 수 없기 때문에,
앱 내 WebView가 선택된 시간표 데이터를 받을 수 있는 브릿지가 필요합니다.

## 참고 사항
- 기존 웹 팝업의 동작과 전달 payload는 변경되지 않습니다.
- React Native WebView 브리지가 존재하는 경우에만 호출되므로, 일반 웹 환경의 기존 동작에는 영향을 주지 않습니다.
- WebView 브리지는 `react-native-webview` 요구사항에 따라 JSON 문자열을 전달합니다.
- 외부로 전달하는 시간표 데이터는 기존과 동일하게 내부 식별자, 강의 색상, 테마 정보를 제외합니다.