### PR TITLE
빌드 번호 표시를 dev 환경에만 노출

### DIFF
--- a/.github/workflows/deploy-snutt-theme-market-prod-ocir.yml
+++ b/.github/workflows/deploy-snutt-theme-market-prod-ocir.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           docker build -t $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG \
             --build-arg APP_ENV=prod \
-            --build-arg BUILD_NUMBER=$BUILD_NUMBER \
             .
           docker push $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG"


### PR DESCRIPTION
## Summary
- prod 워크플로우에서 `BUILD_NUMBER` build arg 제거
- 빌드 번호(`#N`)가 dev 배포에서만 UI 우하단에 표시됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)