### PR TITLE
web-client - timetablePicker : React Native origin 검사 수정 

### DIFF
--- a/apps/snutt-webclient/src/usecases/timetablePickerService.ts
+++ b/apps/snutt-webclient/src/usecases/timetablePickerService.ts
@@ -1,6 +1,14 @@
 import type { Lecture } from '@/entities/lecture';
 import type { FullTimetable } from '@/entities/timetable';
 
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage(message: string): void;
+    };
+  }
+}
+
 export type SharedLecture = Omit<Lecture, '_id' | 'color' | 'colorIndex'>;
 export type SharedTimetable = Omit<FullTimetable, '_id' | 'user_id' | 'updated_at' | 'theme' | 'lecture_list'> & {
   lecture_list: SharedLecture[];
@@ -32,8 +40,23 @@ export const getTimetablePickerService = (allowedOrigins: readonly string[]): Ti
     isAllowedOrigin,
     sendTimetableToOpener: ({ timetable, targetOrigin, opener }) => {
       // 허용 목록 밖 origin으로는 절대 전송하지 않는다 (호출부 검증 누락 대비).
+
+      const message = {
+        type: 'SNUTT_TIMETABLE_SELECTED',
+        payload: toSharedTimetable(timetable),
+      };
+
+      // React Native WebView 환경
+      if (window.ReactNativeWebView) {
+        if (!isAllowedOrigin(window.location.origin)) return;
+        window.ReactNativeWebView.postMessage(JSON.stringify(message));
+        return;
+      }
+
+      // 일반 웹 환경
       if (!isAllowedOrigin(targetOrigin)) return;
-      opener.postMessage({ type: 'SNUTT_TIMETABLE_SELECTED', payload: toSharedTimetable(timetable) }, targetOrigin);
+      opener.postMessage(message, targetOrigin);
+      
     },
   };
 };

--- a/apps/snutt-webclient/src/usecases/timetablePickerService.ts
+++ b/apps/snutt-webclient/src/usecases/timetablePickerService.ts
@@ -48,7 +48,7 @@ export const getTimetablePickerService = (allowedOrigins: readonly string[]): Ti
 
       // React Native WebView 환경
       if (window.ReactNativeWebView) {
-        if (!isAllowedOrigin(window.location.origin)) return;
+        if (!isAllowedOrigin(targetOrigin)) return;
         window.ReactNativeWebView.postMessage(JSON.stringify(message));
         return;
       }


### PR DESCRIPTION
* 변경 코드 :
  ```
  if (window.ReactNativeWebView) {
    /*
     이전 코드 :
    if (!isAllowedOrigin(window.location.origin)) return;
    */
    if (!isAllowedOrigin(targetOrigin)) return;

    window.ReactNativeWebView.postMessage(JSON.stringify(message));
    return;
  }
  ```
  
React Native 앱에 데이터를 전달해주는 코드에서도, 웹 부분과 같이 `targetOrigin`에 대해서 검사하도록 코드를 수정했습니다.